### PR TITLE
Create Dockerfiles in temp dir

### DIFF
--- a/opam-ci-check.opam
+++ b/opam-ci-check.opam
@@ -21,10 +21,12 @@ depends: [
   "ocaml" {>= "4.14.0"}
   "dune" {>= "3.16"}
   "sexplib"
+  "bos" {>= "0.2.1"}
   "cmdliner" {>= "1.1.1"}
   "opam-format" {>= "2.3.0~alpha1"}
   "opam-state" {>= "2.3.0~alpha1"}
   "ocaml-version" {>= "3.6.9"}
+  "dockerfile-opam" {>= "6.3.0"}
   "obuilder-spec"
   "odoc" {with-doc}
   "bos" {>= "0.2.1"}

--- a/opam-ci-check/bin/dune
+++ b/opam-ci-check/bin/dune
@@ -1,5 +1,5 @@
 (executable
  (public_name opam-ci-check)
  (name main)
- (libraries opam_ci_check cmdliner)
+ (libraries opam_ci_check cmdliner dockerfile-opam)
  (package opam-ci-check))

--- a/opam-ci-check/bin/main.ml
+++ b/opam-ci-check/bin/main.ml
@@ -53,8 +53,8 @@ let build_run_spec spec_type pkg opam_repository =
   let pkg = OpamPackage.of_string pkg in
   let config = make_config pkg spec_type in
   let base = Spec.Docker ("ocaml/opam:" ^ Variant.docker_tag config.variant) in
-  let status = Test.build_run_spec ~opam_repository ~base config in
-  if status > 0 then Error "Failed to build and test the package" else Ok ()
+  Test.build_run_spec ~opam_repository ~base config
+  |> Result.map_error (fun _ -> "Failed to build and test the package")
 
 let make_abs_path s =
   if Filename.is_relative s then Filename.concat (Sys.getcwd ()) s else s

--- a/opam-ci-check/lib/dune
+++ b/opam-ci-check/lib/dune
@@ -7,7 +7,8 @@
   opam-format
   opam-state
   sexplib
-  str
   bos
+  fpath
+  str
   ocaml-version
   obuilder-spec))

--- a/opam-ci-check/lib/test.ml
+++ b/opam-ci-check/lib/test.ml
@@ -11,3 +11,23 @@ let error_to_string : error -> string =
   Printf.sprintf "Failed to install %s\nError: %s\n"
     (OpamPackage.to_string pkg)
     (Printexc.to_string err)
+
+let or_raise = function Ok () -> () | Error (`Msg m) -> raise (Failure m)
+
+let build_run_spec ~opam_repository ~base config =
+  let spec = Opam_build.build_spec ~local:true ~for_docker:true ~base config in
+  let dockerfile =
+    Obuilder_spec.Docker.dockerfile_of_spec ~buildkit:false ~os:`Unix spec
+  in
+  (* FIXME: Clone/copy the repo to a tmp dir and build in that? *)
+  let dir = Fpath.v opam_repository in
+  let dockerignore = ".git" in
+  Bos.OS.File.write Fpath.(dir / "Dockerfile") (dockerfile ^ "\n") |> or_raise;
+  Bos.OS.File.write Fpath.(dir / ".dockerignore") dockerignore |> or_raise;
+  let cmd =
+    [ "docker"; "build"; "--no-cache"; "--progress=plain"; "--"; "." ]
+  in
+  let command = String.concat " " cmd in
+  (* Execute the command with dir as CWD *)
+  Sys.chdir opam_repository;
+  Sys.command command

--- a/opam-ci-check/lib/test.ml
+++ b/opam-ci-check/lib/test.ml
@@ -12,22 +12,38 @@ let error_to_string : error -> string =
     (OpamPackage.to_string pkg)
     (Printexc.to_string err)
 
-let or_raise = function Ok () -> () | Error (`Msg m) -> raise (Failure m)
+let (let*) = Result.bind
 
 let build_run_spec ~opam_repository ~base config =
   let spec = Opam_build.build_spec ~local:true ~for_docker:true ~base config in
   let dockerfile =
     Obuilder_spec.Docker.dockerfile_of_spec ~buildkit:false ~os:`Unix spec
   in
-  (* FIXME: Clone/copy the repo to a tmp dir and build in that? *)
+  (* TODO: Use docker ability to build form git repos to default to official opam repo
+     https://docs.docker.com/build/concepts/context/#git-repositories *)
   let dir = Fpath.v opam_repository in
-  let dockerignore = ".git" in
-  Bos.OS.File.write Fpath.(dir / "Dockerfile") (dockerfile ^ "\n") |> or_raise;
-  Bos.OS.File.write Fpath.(dir / ".dockerignore") dockerignore |> or_raise;
-  let cmd =
-    [ "docker"; "build"; "--no-cache"; "--progress=plain"; "--"; "." ]
-  in
-  let command = String.concat " " cmd in
-  (* Execute the command with dir as CWD *)
-  Sys.chdir opam_repository;
-  Sys.command command
+  let dockerignore = ".git\nREADME.md\n" in
+  ()
+  |> Bos.OS.Dir.with_tmp "opam-ci-check-build-%s" (
+    (* Create the docker file and ignore file in the tmp dir to avoid polluting the opam-repo  *)
+    fun tmp_dir () ->
+      let dockerfile_path = Fpath.(tmp_dir / "Dockerfile") in
+      let* () =
+        (* See https://docs.docker.com/build/concepts/context/#filename-and-location *)
+        Bos.OS.File.write Fpath.(tmp_dir / "Dockerfile.dockerignore") dockerignore
+      in
+      let* () = Bos.OS.File.write dockerfile_path dockerfile in
+      let* () = Bos.OS.Dir.set_current dir in
+      let cmd =
+        Bos.Cmd.(v "docker"
+                 %  "build"
+                 % "--no-cache"
+                 % "--progress=plain"
+                 % "--file" % Fpath.to_string dockerfile_path
+                 % "--" % "." )
+      in
+      match Bos.OS.Cmd.(in_string dockerfile |> run_in cmd) with
+      | Ok () -> Ok ()
+      | Error (`Msg err) -> Error (`Msg ("Failed to build and test the package: " ^ err))
+  )
+  |> Result.join

--- a/opam-ci-check/lib/test.mli
+++ b/opam-ci-check/lib/test.mli
@@ -7,3 +7,8 @@ type error = OpamPackage.t * exn
 
 val error_to_string : error -> string
 
+val build_run_spec :
+  opam_repository:string ->
+  base:Spec.base ->
+  Spec.t ->
+  int

--- a/opam-ci-check/lib/test.mli
+++ b/opam-ci-check/lib/test.mli
@@ -8,6 +8,7 @@ type error = OpamPackage.t * exn
 val error_to_string : error -> string
 
 val build_run_spec :
+  ?use_cache:bool ->
   opam_repository:string ->
   base:Spec.base ->
   Spec.t ->

--- a/opam-ci-check/lib/test.mli
+++ b/opam-ci-check/lib/test.mli
@@ -11,4 +11,4 @@ val build_run_spec :
   opam_repository:string ->
   base:Spec.base ->
   Spec.t ->
-  int
+  (unit, Rresult.R.msg) result


### PR DESCRIPTION
Rather than having to copy the repo into a temp dir, we can create the dockerfile (and the dockerignore) in a temp file and refer to those from within the repo to copied into the container.

This also suggests using Bos for the cmd handling, to streamline error handling by working within the result monad.